### PR TITLE
Persist reading list in localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ An App to track reading using React.
    ```
 
 The app will be available at `http://localhost:5173` by default.
+
+## Data Persistence
+
+Books you add are stored in your browser's local storage. They will remain
+available when you refresh or revisit the page from the same device.

--- a/src/ReadingTracker.jsx
+++ b/src/ReadingTracker.jsx
@@ -8,6 +8,24 @@ const ReadingTracker = () => {
   const [showAddBook, setShowAddBook] = useState(false);
   const [editingYesterday, setEditingYesterday] = useState(false);
 
+  // Load saved books from localStorage on first render
+  useEffect(() => {
+    const stored = localStorage.getItem('reading-tracker-books');
+    if (stored) {
+      try {
+        setBooks(JSON.parse(stored));
+      } catch {
+        // ignore parsing errors and start fresh
+        setBooks([]);
+      }
+    }
+  }, []);
+
+  // Persist books whenever they change
+  useEffect(() => {
+    localStorage.setItem('reading-tracker-books', JSON.stringify(books));
+  }, [books]);
+
   const addBook = (title, totalPages, targetDays) => {
     const newBook = {
       id: Date.now(),


### PR DESCRIPTION
## Summary
- persist books across refresh by loading/saving to `localStorage`
- update docs about data persistence

## Testing
- `npm test`
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619047e1bc832a8fa80226ca8eb149