### PR TITLE
Refactor tracker logic

### DIFF
--- a/src/bookMetrics.js
+++ b/src/bookMetrics.js
@@ -1,0 +1,17 @@
+export const calculateDailyGoal = (book) => {
+  if (book.status !== 'reading' || !book.targetDate) return 0;
+
+  const today = new Date();
+  const target = new Date(book.targetDate);
+  const daysRemaining = Math.ceil((target - today) / (1000 * 60 * 60 * 24));
+
+  if (daysRemaining <= 0) return book.totalPages - book.yesterdayPage;
+
+  const pagesRemaining = book.totalPages - book.yesterdayPage;
+  return Math.ceil(pagesRemaining / daysRemaining);
+};
+
+export const getTodaysTarget = (book) => {
+  const dailyGoal = calculateDailyGoal(book);
+  return Math.min(book.yesterdayPage + dailyGoal, book.totalPages);
+};

--- a/src/bookStorage.js
+++ b/src/bookStorage.js
@@ -1,0 +1,86 @@
+import { useState, useEffect } from 'react';
+
+const STORAGE_KEY = 'reading-tracker-books';
+
+export function useBookStorage() {
+  const [books, setBooks] = useState([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        setBooks(JSON.parse(stored));
+      } catch {
+        setBooks([]);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(books));
+  }, [books]);
+
+  const addBook = (title, totalPages, targetDays) => {
+    const newBook = {
+      id: Date.now(),
+      title,
+      totalPages: parseInt(totalPages),
+      targetDays: parseInt(targetDays),
+      currentPage: 0,
+      yesterdayPage: 0,
+      status: 'want-to-read',
+      startDate: null,
+      targetDate: null,
+      dailyProgress: []
+    };
+    setBooks(bks => [...bks, newBook]);
+  };
+
+  const updateBook = (bookId, updates) => {
+    setBooks(bks => bks.map(b => (b.id === bookId ? { ...b, ...updates } : b)));
+  };
+
+  const deleteBook = (bookId) => {
+    setBooks(bks => bks.filter(b => b.id !== bookId));
+  };
+
+  const startReading = (bookId) => {
+    const book = books.find(b => b.id === bookId);
+    if (!book) return;
+    const today = new Date();
+    const targetDate = new Date(today);
+    targetDate.setDate(today.getDate() + book.targetDays);
+
+    updateBook(bookId, {
+      status: 'reading',
+      startDate: today.toISOString().split('T')[0],
+      targetDate: targetDate.toISOString().split('T')[0]
+    });
+  };
+
+  const updateCurrentPage = (bookId, newPage) => {
+    const book = books.find(b => b.id === bookId);
+    if (!book) return;
+    const page = Math.min(parseInt(newPage) || 0, book.totalPages);
+    const status = page >= book.totalPages ? 'read' : book.status;
+    updateBook(bookId, { currentPage: page, status });
+  };
+
+  const updateYesterdayPage = (bookId, newPage) => {
+    const book = books.find(b => b.id === bookId);
+    if (!book) return;
+    const page = Math.min(parseInt(newPage) || 0, book.totalPages);
+    const currentPage = Math.max(book.currentPage, parseInt(newPage) || 0);
+    updateBook(bookId, { yesterdayPage: page, currentPage });
+  };
+
+  return {
+    books,
+    addBook,
+    startReading,
+    updateCurrentPage,
+    updateYesterdayPage,
+    deleteBook
+  };
+}
+


### PR DESCRIPTION
## Summary
- separate persistence logic into `bookStorage`
- add `bookMetrics` for computing reading metrics
- refactor `ReadingTracker` to use new modules
- fix details view not loading due to missing `useEffect` import

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6862369e8bc0832aa7629cb7a93eef07