### PR TITLE
Fix yesterday page label alignment

### DIFF
--- a/src/ReadingTracker.jsx
+++ b/src/ReadingTracker.jsx
@@ -330,7 +330,7 @@ const ReadingTracker = () => {
             <div>
               <div className="flex items-center justify-between mb-2 relative">
                 <div className="flex items-center gap-1">
-                  <label className="block text-xs font-medium text-gray-600">Yesterday's Page</label>
+                  <label className="block text-sm font-medium text-gray-600">Yesterday's Page</label>
                   <button
                     type="button"
                     onClick={() => setShowYesterdayInfo(!showYesterdayInfo)}


### PR DESCRIPTION
## Summary
- make Yesterday's Page label the same size as Current Page

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6862ea392fac832ab13b4293f1257501