### PR TITLE
Add reading time estimate and session deletion

### DIFF
--- a/src/bookStorage.js
+++ b/src/bookStorage.js
@@ -136,6 +136,13 @@ export function useBookStorage() {
     });
   };
 
+  const deleteReadingSession = (bookId, sessionId) => {
+    const book = books.find(b => b.id === bookId);
+    if (!book) return;
+    const sessions = (book.readingSessions || []).filter(s => s.id !== sessionId);
+    updateBook(bookId, { readingSessions: sessions });
+  };
+
   return {
     books,
     addBook,
@@ -145,7 +152,8 @@ export function useBookStorage() {
     updateCurrentPage,
     updateYesterdayPage,
     deleteBook,
-    updateTitle
+    updateTitle,
+    deleteReadingSession
   };
 }
 


### PR DESCRIPTION
## Summary
- compute average reading speed ignoring zero-page sessions
- show estimated minutes left for today's pages in the book detail view
- allow deleting individual reading sessions

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6864fd62a668832abf5c819722e1daaa